### PR TITLE
Improve SwiftUI Image init performance and fix warning

### DIFF
--- a/Sources/CIImage-Filters.swift
+++ b/Sources/CIImage-Filters.swift
@@ -8,6 +8,7 @@ import CoreImage.CIFilterBuiltins
 import CoreML
 import AVFoundation
 
+@available(iOS 13, macOS 10.15, macCatalyst 13, *)
 public extension CIImage {
 
 	//
@@ -689,7 +690,7 @@ public extension CIImage {
 	///   - useInverseLookupTable: Boolean value used to select the Look Up Table from the AVCameraCalibrationData.
 	///   - active: should this filter be applied
 	/// - Returns: processed new `CIImage`, or identity if `active` is false
-	@available(iOS 13, macOS 10.15, *)
+	@available(iOS 13, macOS 10.15, macCatalyst 14, *)
 	func cameraCalibrationLensCorrection(avcameracalibrationdata: AVCameraCalibrationData,
 										 useInverseLookupTable: Bool = false,
 										 active: Bool = true) -> CIImage {
@@ -1765,7 +1766,7 @@ public extension CIImage {
 	///   - shape: UNKNOWN
 	///   - active: should this filter be applied
 	/// - Returns: processed new `CIImage`, or identity if `active` is false
-	@available(iOS 13, macOS 10.15, *)
+	@available(iOS 13, macOS 10.15, macCatalyst 14, *)
 	func depthBlurEffect(disparityImage: CIImage,
 						 matteImage: CIImage,
 						 hairImage: CIImage,

--- a/Sources/Image-Extensions.swift
+++ b/Sources/Image-Extensions.swift
@@ -20,7 +20,7 @@ public extension Image {
 		if let cgImage = Self.context.createCGImage(ciImage, from: ciImage.extent) {
 			self.init(cgImage, scale: 1.0, orientation: .up, label: Text(""))
 		} else {
-			self.init(systemName: "unknown")
+			self.init(systemName: "questionmark")
 		}
 #elseif canImport(AppKit)
 		// Looks like the NSCIImageRep is slightly better optimized for repeated runs,

--- a/Sources/Image-Extensions.swift
+++ b/Sources/Image-Extensions.swift
@@ -11,14 +11,13 @@ import CoreImage
 import SwiftUI
 
 public extension Image {
+    private static let context = CIContext(options: nil)
 
 	init(ciImage: CIImage) {
 
 #if canImport(UIKit)
 		// Note that making a UIImage and then using that to initialize the Image doesn't seem to work, but CGImage is fine.
-		// Possible optimization - store and reuse a CIContext
-		let context = CIContext(options: nil)
-		if let cgImage = context.createCGImage(ciImage, from: ciImage.extent) {
+		if let cgImage = Self.context.createCGImage(ciImage, from: ciImage.extent) {
 			self.init(cgImage, scale: 1.0, orientation: .up, label: Text(""))
 		} else {
 			self.init(systemName: "unknown")


### PR DESCRIPTION
Before the improvement:
https://github.com/danwood/SwiftUICoreImage/assets/759680/0f8229e5-cdf5-46fc-b9e9-1beda6a4fc94

After the improvement:
https://github.com/danwood/SwiftUICoreImage/assets/759680/12dc825b-e0aa-4ce5-b356-3db18e7f3a76

Also, I have some cases, where I initialize with an `CIImage.empty()` and it falls in the `else` case. The `unknown` is now a known SF Symbol, so it fails and produce a warning:
`No symbol named 'unknown' found in system symbol set`
I have changed it to `questionmark`.